### PR TITLE
Chaining improvements.

### DIFF
--- a/QuerySpecification/src/QuerySpecification/Builder/IIncludableSpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/IIncludableSpecificationBuilder.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace PozitronDev.QuerySpecification
 {
-    public interface IIncludableSpecificationBuilder<T, out TProperty>
+    public interface IIncludableSpecificationBuilder<T, out TProperty> : ISpecificationBuilder<T>
     {
         IIncludeAggregator Aggregator { get; }
     }

--- a/QuerySpecification/src/QuerySpecification/Builder/IOrderedSpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/IOrderedSpecificationBuilder.cs
@@ -5,9 +5,7 @@ using System.Text;
 
 namespace PozitronDev.QuerySpecification
 {
-    public interface IOrderedSpecificationBuilder<T>
+    public interface IOrderedSpecificationBuilder<T> : ISpecificationBuilder<T>
     {
-        IOrderedSpecificationBuilder<T> ThenBy(Expression<Func<T, object?>> orderExpression);
-        IOrderedSpecificationBuilder<T> ThenByDescending(Expression<Func<T, object?>> orderExpression);
     }
 }

--- a/QuerySpecification/src/QuerySpecification/Builder/ISpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/ISpecificationBuilder.cs
@@ -7,24 +7,11 @@ namespace PozitronDev.QuerySpecification
 {
     public interface ISpecificationBuilder<T, TResult> : ISpecificationBuilder<T>
     {
-        ISpecificationBuilder<T, TResult> Select(Expression<Func<T, TResult>> selector);
-        ISpecificationBuilder<T, TResult> InMemory(Func<List<TResult>, List<TResult>> predicate);
+        new Specification<T, TResult> Specification { get; }
     }
 
     public interface ISpecificationBuilder<T>
     {
-        ISpecificationBuilder<T> Where(Expression<Func<T, bool>> criteria);
-        IOrderedSpecificationBuilder<T> OrderBy(Expression<Func<T, object?>> orderExpression);
-        IOrderedSpecificationBuilder<T> OrderByDescending(Expression<Func<T, object?>> orderExpression);
-        IIncludableSpecificationBuilder<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> includeExpression);
-        ISpecificationBuilder<T> Include(string includeString);
-        ISpecificationBuilder<T> Search(Expression<Func<T, string>> selector, string searchTerm, int searchGroup = 1);
-        
-        ISpecificationBuilder<T> Take(int take);
-        ISpecificationBuilder<T> Skip(int skip);
-        [Obsolete]
-        ISpecificationBuilder<T> Paginate(int skip, int take);
-        
-        ISpecificationBuilder<T> InMemory(Func<List<T>, List<T>> predicate);
+        Specification<T> Specification { get; }
     }
 }

--- a/QuerySpecification/src/QuerySpecification/Builder/IncludableBuilderExtensions.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/IncludableBuilderExtensions.cs
@@ -8,25 +8,25 @@ namespace PozitronDev.QuerySpecification
     public static class IncludableBuilderExtensions
     {
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
-            this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> value,
+            this IIncludableSpecificationBuilder<TEntity, TPreviousProperty> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
             var propertyName = (thenIncludeExpression.Body as MemberExpression)?.Member?.Name;
-            value.Aggregator.AddNavigationPropertyName(propertyName);
+            previousBuilder.Aggregator.AddNavigationPropertyName(propertyName);
 
-            return new IncludableSpecificationBuilder<TEntity, TProperty>(value.Aggregator);
+            return new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.Aggregator);
         }
 
         public static IIncludableSpecificationBuilder<TEntity, TProperty> ThenInclude<TEntity, TPreviousProperty, TProperty>(
-            this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> value,
+            this IIncludableSpecificationBuilder<TEntity, IEnumerable<TPreviousProperty>> previousBuilder,
             Expression<Func<TPreviousProperty, TProperty>> thenIncludeExpression)
             where TEntity : class
         {
             var propertyName = (thenIncludeExpression.Body as MemberExpression)?.Member?.Name;
-            value.Aggregator.AddNavigationPropertyName(propertyName);
+            previousBuilder.Aggregator.AddNavigationPropertyName(propertyName);
 
-            return new IncludableSpecificationBuilder<TEntity, TProperty>(value.Aggregator);
+            return new IncludableSpecificationBuilder<TEntity, TProperty>(previousBuilder.Specification, previousBuilder.Aggregator);
         }
     }
 }

--- a/QuerySpecification/src/QuerySpecification/Builder/IncludableSpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/IncludableSpecificationBuilder.cs
@@ -6,10 +6,13 @@ namespace PozitronDev.QuerySpecification
 {
     public class IncludableSpecificationBuilder<T, TProperty> : IIncludableSpecificationBuilder<T, TProperty>
     {
+        public Specification<T> Specification { get; }
+
         public IIncludeAggregator Aggregator { get; }
 
-        public IncludableSpecificationBuilder(IIncludeAggregator aggregator)
+        public IncludableSpecificationBuilder(Specification<T> specification, IIncludeAggregator aggregator)
         {
+            Specification = specification;
             Aggregator = aggregator;
         }
     }

--- a/QuerySpecification/src/QuerySpecification/Builder/OrderedBuilderExtensions.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/OrderedBuilderExtensions.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace PozitronDev.QuerySpecification
+{
+    public static class OrderedBuilderExtensions
+    {
+        public static IOrderedSpecificationBuilder<T> ThenBy<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)orderedBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.ThenBy));
+            
+            return orderedBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> ThenByDescending<T>(
+            this IOrderedSpecificationBuilder<T> orderedBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)orderedBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.ThenByDescending));
+            
+            return orderedBuilder;
+        }
+    }
+}

--- a/QuerySpecification/src/QuerySpecification/Builder/OrderedSpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/OrderedSpecificationBuilder.cs
@@ -7,23 +7,13 @@ namespace PozitronDev.QuerySpecification
 {
     public class OrderedSpecificationBuilder<T> : IOrderedSpecificationBuilder<T>
     {
-        private readonly Specification<T> specification;
+        public Specification<T> Specification { get; }
 
         public OrderedSpecificationBuilder(Specification<T> specification)
         {
-            this.specification = specification;
+            this.Specification = specification;
         }
 
-        public IOrderedSpecificationBuilder<T> ThenBy(Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.ThenBy));
-            return this;
-        }
 
-        public IOrderedSpecificationBuilder<T> ThenByDescending(Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.ThenByDescending));
-            return this;
-        }
     }
 }

--- a/QuerySpecification/src/QuerySpecification/Builder/SpecificationBuilder.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/SpecificationBuilder.cs
@@ -7,107 +7,22 @@ namespace PozitronDev.QuerySpecification
 {
     public class SpecificationBuilder<T, TResult> : SpecificationBuilder<T>, ISpecificationBuilder<T, TResult>
     {
-        private readonly Specification<T, TResult> specification;
+        public new Specification<T, TResult> Specification { get; }
 
-        public SpecificationBuilder(Specification<T, TResult> specification) : base(specification)
+        public SpecificationBuilder(Specification<T, TResult> specification) 
+            : base(specification)
         {
-            this.specification = specification;
-        }
-
-        public ISpecificationBuilder<T, TResult> Select(Expression<Func<T, TResult>> selector)
-        {
-            specification.Selector = selector;
-            return this;
-        }
-
-        public ISpecificationBuilder<T, TResult> InMemory(Func<List<TResult>, List<TResult>> predicate)
-        {
-            specification.InMemory = predicate;
-            return this;
+            this.Specification = specification;
         }
     }
 
     public class SpecificationBuilder<T> : ISpecificationBuilder<T>
     {
-        private readonly Specification<T> specification;
-        private readonly IOrderedSpecificationBuilder<T> orderedSpecificationBuilder;
+        public Specification<T> Specification { get; }
 
         public SpecificationBuilder(Specification<T> specification)
         {
-            this.specification = specification;
-            this.orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specification);
-        }
-
-        public ISpecificationBuilder<T> Where(Expression<Func<T, bool>> criteria)
-        {
-            ((List<Expression<Func<T, bool>>>)specification.WhereExpressions).Add(criteria);
-            return this;
-        }
-
-        public IOrderedSpecificationBuilder<T> OrderBy(Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.OrderBy));
-            return orderedSpecificationBuilder;
-        }
-
-        public IOrderedSpecificationBuilder<T> OrderByDescending(Expression<Func<T, object?>> orderExpression)
-        {
-            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specification.OrderExpressions).Add((orderExpression, OrderTypeEnum.OrderByDescending));
-            return orderedSpecificationBuilder;
-        }
-
-        public IIncludableSpecificationBuilder<T, TProperty> Include<TProperty>(Expression<Func<T, TProperty>> includeExpression)
-        {
-            var aggregator = new IncludeAggregator((includeExpression.Body as MemberExpression)?.Member?.Name);
-            var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(aggregator);
-
-            ((List<IIncludeAggregator>)specification.IncludeAggregators).Add(aggregator);
-            return includeBuilder;
-        }
-
-        public ISpecificationBuilder<T> Include(string includeString)
-        {
-            ((List<string>)specification.IncludeStrings).Add(includeString);
-            return this;
-        }
-
-        public ISpecificationBuilder<T> Search(Expression<Func<T, string>> selector, string searchTerm, int searchGroup = 1)
-        {
-            ((List<(Expression<Func<T, string>> Selector, string SearchTerm, int SearchGroup)>)specification.SearchCriterias).Add((selector, searchTerm, searchGroup));
-            return this;
-        }
-
-
-        public ISpecificationBuilder<T> Take(int take)
-        {
-            if (specification.Take != null) throw new DuplicateTakeException();
-
-            specification.Take = take;
-            specification.IsPagingEnabled = true;
-            return this;
-        }
-
-        public ISpecificationBuilder<T> Skip(int skip)
-        {
-            if (specification.Skip != null) throw new DuplicateSkipException();
-
-            specification.Skip = skip;
-            specification.IsPagingEnabled = true;
-            return this;
-        }
-
-        public ISpecificationBuilder<T> Paginate(int skip, int take)
-        {
-            Skip(skip);
-            Take(take);
-            return this;
-        }
-
-
-        public ISpecificationBuilder<T> InMemory(Func<List<T>, List<T>> predicate)
-        {
-            specification.InMemory = predicate;
-            return this;
+            this.Specification = specification;
         }
     }
 }

--- a/QuerySpecification/src/QuerySpecification/Builder/SpecificationBuilderExtensions.cs
+++ b/QuerySpecification/src/QuerySpecification/Builder/SpecificationBuilderExtensions.cs
@@ -1,0 +1,135 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using System.Text;
+
+namespace PozitronDev.QuerySpecification
+{
+    public static class SpecificationBuilderExtensions
+    {
+        public static ISpecificationBuilder<T> Where<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, bool>> criteria)
+        {
+            ((List<Expression<Func<T, bool>>>)specificationBuilder.Specification.WhereExpressions).Add(criteria);
+
+            return specificationBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> OrderBy<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.OrderBy));
+
+            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
+
+            return orderedSpecificationBuilder;
+        }
+
+        public static IOrderedSpecificationBuilder<T> OrderByDescending<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, object?>> orderExpression)
+        {
+            ((List<(Expression<Func<T, object?>> OrderExpression, OrderTypeEnum OrderType)>)specificationBuilder.Specification.OrderExpressions)
+                .Add((orderExpression, OrderTypeEnum.OrderByDescending));
+
+            var orderedSpecificationBuilder = new OrderedSpecificationBuilder<T>(specificationBuilder.Specification);
+
+            return orderedSpecificationBuilder;
+        }
+
+        public static IIncludableSpecificationBuilder<T, TProperty> Include<T, TProperty>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, TProperty>> includeExpression)
+        {
+            var aggregator = new IncludeAggregator((includeExpression.Body as MemberExpression)?.Member?.Name);
+            var includeBuilder = new IncludableSpecificationBuilder<T, TProperty>(specificationBuilder.Specification, aggregator);
+
+            ((List<IIncludeAggregator>)specificationBuilder.Specification.IncludeAggregators).Add(aggregator);
+            return includeBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Include<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            string includeString)
+        {
+            ((List<string>)specificationBuilder.Specification.IncludeStrings).Add(includeString);
+            return specificationBuilder;
+        }
+
+
+        public static ISpecificationBuilder<T> Search<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Expression<Func<T, string>> selector, 
+            string searchTerm, 
+            int searchGroup = 1)
+        {
+            ((List<(Expression<Func<T, string>> Selector, string SearchTerm, int SearchGroup)>)specificationBuilder.Specification.SearchCriterias)
+                .Add((selector, searchTerm, searchGroup));
+            
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Take<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int take)
+        {
+            if (specificationBuilder.Specification.Take != null) throw new DuplicateTakeException();
+
+            specificationBuilder.Specification.Take = take;
+            specificationBuilder.Specification.IsPagingEnabled = true;
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Skip<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int skip)
+        {
+            if (specificationBuilder.Specification.Skip != null) throw new DuplicateSkipException();
+
+            specificationBuilder.Specification.Skip = skip;
+            specificationBuilder.Specification.IsPagingEnabled = true;
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> Paginate<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            int skip, 
+            int take)
+        {
+            specificationBuilder.Skip(skip);
+            specificationBuilder.Take(take);
+            
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T> InMemory<T>(
+            this ISpecificationBuilder<T> specificationBuilder,
+            Func<List<T>, List<T>> predicate)
+        {
+            specificationBuilder.Specification.InMemory = predicate;
+            
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T, TResult> Select<T, TResult>(
+            this ISpecificationBuilder<T, TResult> specificationBuilder,
+            Expression<Func<T, TResult>> selector)
+        {
+            specificationBuilder.Specification.Selector = selector;
+
+            return specificationBuilder;
+        }
+
+        public static ISpecificationBuilder<T, TResult> InMemory<T, TResult>(
+            this ISpecificationBuilder<T, TResult> specificationBuilder,
+            Func<List<TResult>, List<TResult>> predicate)
+        {
+            specificationBuilder.Specification.InMemory = predicate;
+            
+            return specificationBuilder;
+        }
+    }
+}


### PR DESCRIPTION
The internal builder infrastructure is refactored. No breaking API changes for end users.
Now, everything can be written in one large chain. You can go back after `Then` definitions, and continue building the specification.

```
public class StoresOrderedSpecByName : Specification<Store>
{
    public StoresOrderedSpecByName()
    {
        Query.Where(x => x.Name == "something")
            .Include(x => x.Company)
                .ThenInclude(x => x.Stores)
            .Include(x => x.Address)
            .OrderBy(x => x.Name)
                .ThenBy(x => x.Id)
            .Search(x => x.Name, "something")
            .Skip(2)
            .Take(10)
            .InMemory(x =>
            {
                return x.Where(q => q.Company!.CountryId == 1).ToList();
            });
    }
}
```