### PR TITLE
Publish symbols as a separate package.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,6 @@
   <ItemGroup Label="Package dependencies">
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="8.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="8.0.8" />
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
   </ItemGroup>
   
   <ItemGroup Label="Test projects dependencies">

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019 Fati Iseni
+Copyright (c) 2024 Fati Iseni
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/clean.sh
+++ b/clean.sh
@@ -46,7 +46,7 @@ find "$WorkingDir/" -type f -name "*.csproj.user" -exec rm -rf {} \; > /dev/null
 }
 
 ########## Delete test and coverage artifacts
-deleteUserCsprojFiles()
+deleteTestResults()
 {
 echo "Deleting test and coverage artifacts...";
 
@@ -75,7 +75,7 @@ elif [ "$1" = "logs" ]; then
 elif [ "$1" = "user" ]; then
 	deleteUserCsprojFiles;
 elif [ "$1" = "coverages" ]; then
-	deleteUserCsprojFiles;
+	deleteTestResults;
 elif [ "$1" = "branches" ]; then
 	deleteLocalGitBranches;
 else

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -5,39 +5,41 @@
     <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <LangVersion>latest</LangVersion>
+
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>
-    <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <Deterministic>true</Deterministic>
   </PropertyGroup>
 
+  <PropertyGroup Label="Symbols">
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
+    <!--<DebugType>Embedded</DebugType>-->
+    <!--<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>-->
+  </PropertyGroup>
+  
   <PropertyGroup Label="Package MetaData">
     <Authors>Fati Iseni</Authors>
     <Company>Pozitron Group</Company>
-    <Product>Pozitron QuerySpecification</Product>
     <Copyright>Copyright © 2024 Pozitron Group</Copyright>
+    <Product>Pozitron QuerySpecification</Product>
 
+    <PackageProjectUrl>https://github.com/fiseni/QuerySpecification</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/fiseni/QuerySpecification</RepositoryUrl>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <RepositoryType>git</RepositoryType>
-    <RepositoryUrl>https://github.com/fiseni/QuerySpecification</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/fiseni/QuerySpecification</PackageProjectUrl>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIconUrl>https://pozitrongroup.com/PozitronLogo.png</PackageIconUrl>
     <PackageIcon>pozitronicon.png</PackageIcon>
   </PropertyGroup>
-  
-  <ItemGroup>
-    <PackageReference Include="Microsoft.SourceLink.GitHub">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 
   <ItemGroup>
     <None Include="../../pozitronicon.png" Pack="true" PackagePath="\" />
     <None Include="../../README.md" Pack="true" PackagePath="\" />
+    <None Include="../../LICENSE.txt" Pack="true" PackagePath="\" />
   </ItemGroup>
 
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -9,7 +9,8 @@
 
     <GenerateDocumentationFile>false</GenerateDocumentationFile>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
-    <Deterministic>true</Deterministic>
+    <Deterministic>false</Deterministic>
+    <ContinuousIntegrationBuild Condition="'$(GITHUB_ACTIONS)' == 'true'">true</ContinuousIntegrationBuild>
   </PropertyGroup>
 
   <PropertyGroup Label="Symbols">


### PR DESCRIPTION
- Do not pack the PDB files in the main .nupkg package.
- Publish the PDB files as separate .snupkg packages.
- Enable deterministic builds.