### PR TITLE
Add separate repository with mapper.

### DIFF
--- a/src/QuerySpecification.EntityFrameworkCore/RepositoryWithMapper.cs
+++ b/src/QuerySpecification.EntityFrameworkCore/RepositoryWithMapper.cs
@@ -1,0 +1,67 @@
+﻿namespace Pozitron.QuerySpecification;
+
+public abstract class RepositoryWithMapper<T> : RepositoryBase<T>, IProjectionRepository<T> where T : class
+{
+    private readonly PaginationSettings _paginationSettings = PaginationSettings.Default;
+
+    protected RepositoryWithMapper(DbContext dbContext)
+        : base(dbContext)
+    {
+    }
+    protected RepositoryWithMapper(DbContext dbContext, SpecificationEvaluator specificationEvaluator)
+        : base(dbContext, specificationEvaluator)
+    {
+    }
+    protected RepositoryWithMapper(DbContext dbContext, PaginationSettings paginationSettings)
+        : base(dbContext)
+    {
+        _paginationSettings = paginationSettings;
+    }
+    protected RepositoryWithMapper(DbContext dbContext, SpecificationEvaluator specificationEvaluator, PaginationSettings paginationSettings)
+        : base(dbContext, specificationEvaluator)
+    {
+        _paginationSettings = paginationSettings;
+    }
+
+    protected abstract IQueryable<TResult> Map<TResult>(IQueryable<T> source);
+
+    public virtual async Task<TResult> ProjectToFirstAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default)
+    {
+        var query = GenerateQuery(specification).AsNoTracking();
+
+        var projectedQuery = Map<TResult>(query);
+
+        var result = await projectedQuery.FirstOrDefaultAsync(cancellationToken);
+
+        return result ?? throw new EntityNotFoundException(typeof(T).Name);
+    }
+    public virtual async Task<TResult?> ProjectToFirstOrDefaultAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default)
+    {
+        var query = GenerateQuery(specification).AsNoTracking();
+
+        var projectedQuery = Map<TResult>(query);
+
+        return await projectedQuery.FirstOrDefaultAsync(cancellationToken);
+    }
+    public virtual async Task<List<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default)
+    {
+        var query = GenerateQuery(specification).AsNoTracking();
+
+        var projectedQuery = Map<TResult>(query);
+
+        return await projectedQuery.ToListAsync(cancellationToken);
+    }
+    public virtual async Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, PagingFilter filter, CancellationToken cancellationToken = default)
+    {
+        var query = GenerateQuery(specification, true).AsNoTracking();
+        var projectedQuery = Map<TResult>(query);
+
+        var count = await projectedQuery.CountAsync(cancellationToken);
+        var pagination = new Pagination(_paginationSettings, count, filter);
+
+        projectedQuery = projectedQuery.ApplyPaging(pagination);
+        var data = await projectedQuery.ToListAsync(cancellationToken);
+
+        return new PagedResult<TResult>(data, pagination);
+    }
+}

--- a/src/QuerySpecification/IProjectionRepository.cs
+++ b/src/QuerySpecification/IProjectionRepository.cs
@@ -1,0 +1,9 @@
+﻿namespace Pozitron.QuerySpecification;
+
+public interface IProjectionRepository<T> where T : class
+{
+    Task<TResult> ProjectToFirstAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
+    Task<TResult?> ProjectToFirstOrDefaultAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
+    Task<List<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
+    Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, PagingFilter filter, CancellationToken cancellationToken = default);
+}

--- a/src/QuerySpecification/IReadRepositoryBase.cs
+++ b/src/QuerySpecification/IReadRepositoryBase.cs
@@ -18,10 +18,5 @@ public interface IReadRepositoryBase<T> where T : class
     Task<bool> AnyAsync(CancellationToken cancellationToken = default);
     Task<bool> AnyAsync(Specification<T> specification, CancellationToken cancellationToken = default);
     Task<bool> AnyAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-
     IAsyncEnumerable<T> AsAsyncEnumerable(Specification<T> specification);
-    Task<TResult> ProjectToFirstAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<TResult?> ProjectToFirstOrDefaultAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<List<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, PagingFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/QuerySpecification/IRepositoryBase.cs
+++ b/src/QuerySpecification/IRepositoryBase.cs
@@ -1,6 +1,6 @@
 ﻿namespace Pozitron.QuerySpecification;
 
-public interface IRepositoryBase<T> where T : class
+public interface IRepositoryBase<T> : IReadRepositoryBase<T> where T : class
 {
     Task<T> AddAsync(T entity, CancellationToken cancellationToken = default);
     Task<IEnumerable<T>> AddRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
@@ -8,21 +8,4 @@ public interface IRepositoryBase<T> where T : class
     Task DeleteAsync(T entity, CancellationToken cancellationToken = default);
     Task DeleteRangeAsync(IEnumerable<T> entities, CancellationToken cancellationToken = default);
     Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
-
-    ValueTask<T?> FindAsync<TId>(TId id, CancellationToken cancellationToken = default) where TId : notnull;
-    Task<T> FirstAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<TResult> FirstAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-    Task<T?> FirstOrDefaultAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<TResult?> FirstOrDefaultAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-    Task<T?> SingleOrDefaultAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<TResult?> SingleOrDefaultAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-    Task<List<T>> ListAsync(CancellationToken cancellationToken = default);
-    Task<List<T>> ListAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<List<TResult>> ListAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-    Task<int> CountAsync(CancellationToken cancellationToken = default);
-    Task<int> CountAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<int> CountAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
-    Task<bool> AnyAsync(CancellationToken cancellationToken = default);
-    Task<bool> AnyAsync(Specification<T> specification, CancellationToken cancellationToken = default);
-    Task<bool> AnyAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
 }

--- a/tests/QuerySpecification.EntityFrameworkCore.Tests/Fixture/Repository.cs
+++ b/tests/QuerySpecification.EntityFrameworkCore.Tests/Fixture/Repository.cs
@@ -3,7 +3,7 @@ using AutoMapper.QueryableExtensions;
 
 namespace Tests.Fixture;
 
-public class Repository<T>(DbContext context) : RepositoryBase<T>(context) where T : class
+public class Repository<T>(DbContext context) : RepositoryWithMapper<T>(context) where T : class
 {
     private static readonly Lazy<IMapper> _mapper = new(() =>
     {

--- a/tests/QuerySpecification.EntityFrameworkCore.Tests/Repositories/RepositoryTests.cs
+++ b/tests/QuerySpecification.EntityFrameworkCore.Tests/Repositories/RepositoryTests.cs
@@ -49,7 +49,7 @@ public class RepositoryTests(TestFactory factory) : IntegrationTest(factory)
         Accessors<object>.PaginationSettingsOf(repo).Should().BeSameAs(paginationSettings);
     }
 
-    public class Repository<T> : RepositoryBase<T> where T : class
+    public class Repository<T> : RepositoryWithMapper<T> where T : class
     {
         public Repository(DbContext context)
             : base(context)
@@ -84,6 +84,6 @@ public class RepositoryTests(TestFactory factory) : IntegrationTest(factory)
         public static extern ref SpecificationEvaluator SpecificationEvaluatorOf(RepositoryBase<T> @this);
 
         [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "_paginationSettings")]
-        public static extern ref PaginationSettings PaginationSettingsOf(RepositoryBase<T> @this);
+        public static extern ref PaginationSettings PaginationSettingsOf(RepositoryWithMapper<T> @this);
     }
 }


### PR DESCRIPTION
- Removed projection methods from `RepositoryBase` and `IReadRepositoryBase`.
- Added `IProjectionRepository` contract defining the ProjectTo APIs.
- Added `RepositoryWithMapper` which inherits `RepositoryBase` and additionally implements the ProjectTo methods.

This way consumers who do not necessarily want to use a generic mapper can keep using `RepositoryBase` and not be forced to implement the abstract `Map` method.