### PR TITLE
Add IPagingFilter interface

### DIFF
--- a/src/QuerySpecification.EntityFrameworkCore/Extensions/IQueryableExtensions.cs
+++ b/src/QuerySpecification.EntityFrameworkCore/Extensions/IQueryableExtensions.cs
@@ -52,7 +52,7 @@ public static class IQueryableExtensions
     /// <returns>A task that represents the asynchronous operation. The task result contains the paged result.</returns>
     public static Task<PagedResult<TSource>> ToPagedResultAsync<TSource>(
       this IQueryable<TSource> source,
-      PagingFilter filter,
+      IPagingFilter filter,
       CancellationToken cancellationToken = default)
       where TSource : class
       => ToPagedResultAsync(source, filter, PaginationSettings.Default, cancellationToken);
@@ -68,7 +68,7 @@ public static class IQueryableExtensions
     /// <returns>A task that represents the asynchronous operation. The task result contains the paged result.</returns>
     public static async Task<PagedResult<TSource>> ToPagedResultAsync<TSource>(
       this IQueryable<TSource> source,
-      PagingFilter filter,
+      IPagingFilter filter,
       PaginationSettings paginationSettings,
       CancellationToken cancellationToken = default)
       where TSource : class

--- a/src/QuerySpecification.EntityFrameworkCore/RepositoryWithMapper.cs
+++ b/src/QuerySpecification.EntityFrameworkCore/RepositoryWithMapper.cs
@@ -91,7 +91,7 @@ public abstract class RepositoryWithMapper<T> : RepositoryBase<T>, IProjectionRe
     }
 
     /// <inheritdoc/>
-    public virtual async Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, PagingFilter filter, CancellationToken cancellationToken = default)
+    public virtual async Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, IPagingFilter filter, CancellationToken cancellationToken = default)
     {
         var query = GenerateQuery(specification, true).AsNoTracking();
         var projectedQuery = Map<TResult>(query);

--- a/src/QuerySpecification/IProjectionRepository.cs
+++ b/src/QuerySpecification/IProjectionRepository.cs
@@ -47,5 +47,5 @@ public interface IProjectionRepository<T> where T : class
     /// <param name="filter">The paging filter.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the paged list of projected results.</returns>
-    Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, PagingFilter filter, CancellationToken cancellationToken = default);
+    Task<PagedResult<TResult>> ProjectToListAsync<TResult>(Specification<T> specification, IPagingFilter filter, CancellationToken cancellationToken = default);
 }

--- a/src/QuerySpecification/Paging/IPagingFilter.cs
+++ b/src/QuerySpecification/Paging/IPagingFilter.cs
@@ -1,0 +1,17 @@
+﻿namespace Pozitron.QuerySpecification;
+
+/// <summary>
+/// Represents a filter for paging.
+/// </summary>
+public interface IPagingFilter
+{
+    /// <summary>
+    /// Gets the page number.
+    /// </summary>
+    int? Page { get; }
+
+    /// <summary>
+    /// Gets the page size.
+    /// </summary>
+    int? PageSize { get; }
+}

--- a/src/QuerySpecification/Paging/Pagination.cs
+++ b/src/QuerySpecification/Paging/Pagination.cs
@@ -97,7 +97,7 @@ public record Pagination
     /// </summary>
     /// <param name="itemsCount">The total number of items.</param>
     /// <param name="filter">The paging filter.</param>
-    public Pagination(int itemsCount, PagingFilter filter)
+    public Pagination(int itemsCount, IPagingFilter filter)
         : this(PaginationSettings.Default, itemsCount, filter.PageSize, filter.Page)
     {
     }
@@ -119,7 +119,7 @@ public record Pagination
     /// <param name="paginationSettings">The pagination settings.</param>
     /// <param name="itemsCount">The total number of items.</param>
     /// <param name="filter">The paging filter.</param>
-    public Pagination(PaginationSettings paginationSettings, int itemsCount, PagingFilter filter)
+    public Pagination(PaginationSettings paginationSettings, int itemsCount, IPagingFilter filter)
         : this(paginationSettings, itemsCount, filter.PageSize, filter.Page)
     {
     }
@@ -160,9 +160,9 @@ public record Pagination
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetHandledPageSize(PaginationSettings settings, int? pageSize)
     {
-        if (!pageSize.HasValue || pageSize <= 0) return settings.DefaultPageSize;
+        if (!pageSize.HasValue || pageSize.Value <= 0) return settings.DefaultPageSize;
 
-        if (pageSize > settings.DefaultPageSizeLimit) return settings.DefaultPageSizeLimit;
+        if (pageSize.Value > settings.DefaultPageSizeLimit) return settings.DefaultPageSizeLimit;
 
         return pageSize.Value;
     }
@@ -176,7 +176,7 @@ public record Pagination
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static int GetHandledPage(PaginationSettings settings, int handledTotalPages, int? page)
     {
-        if (!page.HasValue || page <= 0) return settings.DefaultPage;
+        if (!page.HasValue || page.Value <= 0) return settings.DefaultPage;
 
         if (page.Value > handledTotalPages) return handledTotalPages;
 

--- a/src/QuerySpecification/Paging/PagingFilter.cs
+++ b/src/QuerySpecification/Paging/PagingFilter.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// Represents a filter for paging.
 /// </summary>
-public record PagingFilter
+public record PagingFilter : IPagingFilter
 {
     /// <summary>
     /// Gets or sets the page number.


### PR DESCRIPTION
The existing `PagingFilter` model might be very constraining for consumers. It's defined as record and has init setters. Consumers might want to manage this data differently.
- Added new `IPagingFilter` interface
- Replaced usages of `PagingFilter` with `IPagingFilter` interface across methods, constructors, and repositories for improved abstraction and flexibility.
- We'll still keep `PagingFilter` for backward compatibility. Now it implements `IPagingFilter`.