### PR TITLE
Rename ListAsync repo methods to ToListAsync. [Breaking Change]

### DIFF
--- a/src/QuerySpecification.EntityFrameworkCore/RepositoryBase.cs
+++ b/src/QuerySpecification.EntityFrameworkCore/RepositoryBase.cs
@@ -124,19 +124,19 @@ public abstract class RepositoryBase<T> : IRepositoryBase<T> where T : class
     }
 
     /// <inheritdoc/>
-    public virtual async Task<List<T>> ListAsync(CancellationToken cancellationToken = default)
+    public virtual async Task<List<T>> ToListAsync(CancellationToken cancellationToken = default)
     {
         return await _dbContext.Set<T>().ToListAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<List<T>> ListAsync(Specification<T> specification, CancellationToken cancellationToken = default)
+    public virtual async Task<List<T>> ToListAsync(Specification<T> specification, CancellationToken cancellationToken = default)
     {
         return await GenerateQuery(specification).ToListAsync(cancellationToken);
     }
 
     /// <inheritdoc/>
-    public virtual async Task<List<TResult>> ListAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default)
+    public virtual async Task<List<TResult>> ToListAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default)
     {
         return await GenerateQuery(specification).ToListAsync(cancellationToken);
     }

--- a/src/QuerySpecification/IReadRepositoryBase.cs
+++ b/src/QuerySpecification/IReadRepositoryBase.cs
@@ -73,7 +73,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the list of all entities.</returns>
-    Task<List<T>> ListAsync(CancellationToken cancellationToken = default);
+    Task<List<T>> ToListAsync(CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a list of entities that match the specification.
@@ -81,7 +81,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// <param name="specification">The specification to evaluate.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the list of entities that match the specification.</returns>
-    Task<List<T>> ListAsync(Specification<T> specification, CancellationToken cancellationToken = default);
+    Task<List<T>> ToListAsync(Specification<T> specification, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets a list of entities that match the specification and projects them to a result.
@@ -90,7 +90,7 @@ public interface IReadRepositoryBase<T> where T : class
     /// <param name="specification">The specification to evaluate.</param>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A task that represents the asynchronous operation. The task result contains the list of entities that match the specification and are projected to a result.</returns>
-    Task<List<TResult>> ListAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
+    Task<List<TResult>> ToListAsync<TResult>(Specification<T, TResult> specification, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Gets the count of all entities.

--- a/tests/QuerySpecification.EntityFrameworkCore.Tests/Repositories/Repository_ToListTests.cs
+++ b/tests/QuerySpecification.EntityFrameworkCore.Tests/Repositories/Repository_ToListTests.cs
@@ -1,7 +1,7 @@
 ﻿namespace Tests.Repositories;
 
 [Collection("SharedCollection")]
-public class Repository_ListTests(TestFactory factory) : IntegrationTest(factory)
+public class Repository_ToListTests(TestFactory factory) : IntegrationTest(factory)
 {
     public record CountryDto(string? Name);
 
@@ -18,7 +18,7 @@ public class Repository_ListTests(TestFactory factory) : IntegrationTest(factory
 
         var repo = new Repository<Country>(DbContext);
 
-        var result = await repo.ListAsync();
+        var result = await repo.ToListAsync();
 
         result.Should().HaveSameCount(expected);
         result.Should().BeEquivalentTo(expected);
@@ -46,7 +46,7 @@ public class Repository_ListTests(TestFactory factory) : IntegrationTest(factory
         spec.Query
             .Where(x => x.Name == "b");
 
-        var result = await repo.ListAsync(spec);
+        var result = await repo.ToListAsync(spec);
 
         result.Should().HaveSameCount(expected);
         result.Should().BeEquivalentTo(expected);
@@ -77,7 +77,7 @@ public class Repository_ListTests(TestFactory factory) : IntegrationTest(factory
             .Where(x => x.Name == "b")
             .Select(x => new CountryDto(x.Name));
 
-        var result = await repo.ListAsync(spec);
+        var result = await repo.ToListAsync(spec);
 
         result.Should().HaveSameCount(expected);
         result.Should().BeEquivalentTo(expected);


### PR DESCRIPTION
We'll update the name of few repository methods from `ListAsync` to the canonical names `ToListAsync`.